### PR TITLE
Merge develop: dependency updates and compatibility fixes

### DIFF
--- a/genslm/__init__.py
+++ b/genslm/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.5a1"
+__version__ = "0.0.6a1"
 
 # Public imports
 from genslm.dataset import SequenceDataset  # noqa

--- a/genslm/cmdline/run_inference.py
+++ b/genslm/cmdline/run_inference.py
@@ -113,9 +113,9 @@ class InferenceSequenceDataset(Dataset):  # type: ignore[type-arg]
         # instead of (batch_size, 1, seq_length)
         sample = {
             "input_ids": batch_encoding["input_ids"].squeeze(),
-            "attention_mask": batch_encoding["attention_mask"],
+            "attention_mask": batch_encoding["attention_mask"].squeeze(),
             "indices": torch.from_numpy(np.array([idx])),
-            "seq_lens": batch_encoding["attention_mask"].sum(1),
+            "seq_lens": batch_encoding["attention_mask"].sum(),
             # Need raw string for hashing
             "na_hash": hashlib.md5(seq.encode("utf-8")).hexdigest(),
         }

--- a/genslm/config.py
+++ b/genslm/config.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Type, TypeVar, Union
 
 import yaml
-from pydantic import BaseSettings as _BaseSettings
-from pydantic import root_validator, validator
+from pydantic import BaseModel, field_validator, model_validator
 
 import genslm
 
@@ -26,17 +25,15 @@ def _resolve_path_exists(value: Optional[Path]) -> Optional[Path]:
 
 
 def path_validator(field: str) -> classmethod:
-    decorator = validator(field, allow_reuse=True)
-    _validator = decorator(_resolve_path_exists)
-    return _validator
+    return field_validator(field)(lambda v: _resolve_path_exists(v))
 
 
-class BaseSettings(_BaseSettings):
+class BaseSettings(BaseModel):
     """Base settings to provide an easier interface to read/write YAML files."""
 
     def dump_yaml(self, cfg_path: PathLike) -> None:
         with open(cfg_path, mode="w") as fp:
-            yaml.dump(json.loads(self.json()), fp, indent=4, sort_keys=False)
+            yaml.dump(json.loads(self.model_dump_json()), fp, indent=4, sort_keys=False)
 
     @classmethod
     def from_yaml(cls: Type[_T], filename: PathLike) -> _T:
@@ -85,6 +82,8 @@ class ReduceLROnPlateauSettings(BaseSettings):
 
 class ModelSettings(BaseSettings):
     """Settings for the DNATransformer model."""
+
+    model_config = {"protected_namespaces": ()}
 
     # logging settings
     wandb_active: bool = False
@@ -213,44 +212,42 @@ class ModelSettings(BaseSettings):
     persistent_workers: bool = True
     """If True, the data loader will not shutdown the worker processes after a dataset has been consumed once."""
 
-    @validator("node_local_path")
+    @field_validator("node_local_path")
+    @classmethod
     def resolve_node_local_path(cls, v: Optional[Path]) -> Optional[Path]:
         # Check if node local path is stored in environment variable
         # Example: v = Path("$PSCRATCH") => str(v)[1:] == "PSCRATCH"
         return None if v is None else Path(os.environ.get(str(v)[1:], v))
 
-    @root_validator
-    def warn_checkpoint_load(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        load_pt_checkpoint = values.get("load_pt_checkpoint")
-        load_ds_checkpoint = values.get("load_ds_checkpoint")
-        if load_pt_checkpoint is not None and load_ds_checkpoint is not None:
+    @model_validator(mode="after")
+    def warn_checkpoint_load(self) -> "ModelSettings":
+        if self.load_pt_checkpoint is not None and self.load_ds_checkpoint is not None:
             warnings.warn(
                 "Both load_pt_checkpoint and load_ds_checkpoint are "
                 "specified in the configuration. Loading from load_pt_checkpoint."
             )
-        return values
+        return self
 
-    @root_validator
-    def warn_checkpoint_steps(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        checkpoint_every_n_train_steps = values.get("checkpoint_every_n_train_steps")
-        checkpoint_every_n_epochs = values.get("checkpoint_every_n_epochs")
+    @model_validator(mode="after")
+    def warn_checkpoint_steps(self) -> "ModelSettings":
         if (
-            checkpoint_every_n_train_steps is not None
-            and checkpoint_every_n_epochs is not None
+            self.checkpoint_every_n_train_steps is not None
+            and self.checkpoint_every_n_epochs is not None
         ):
             warnings.warn(
                 "Both checkpoint_every_n_train_steps and checkpoint_every_n_epochs are "
                 "specified in the configuration. Using checkpoint_every_n_train_steps."
             )
-            values["checkpoint_every_n_epochs"] = None
+            self.checkpoint_every_n_epochs = None
         elif (
-            checkpoint_every_n_train_steps is None and checkpoint_every_n_epochs is None
+            self.checkpoint_every_n_train_steps is None
+            and self.checkpoint_every_n_epochs is None
         ):
             warnings.warn(
                 "Both checkpoint_every_n_train_steps and checkpoint_every_n_epochs are "
                 "missing in the configuration. PLease specify one of these to log checkpoints."
             )
-        return values
+        return self
 
 
 def throughput_config(cfg: ModelSettings) -> ModelSettings:

--- a/genslm/dataset.py
+++ b/genslm/dataset.py
@@ -609,6 +609,6 @@ class SequenceDataset(Dataset):  # type: ignore[type-arg]
         # instead of (batch_size, 1, seq_length)
         sample = {
             "input_ids": batch_encoding["input_ids"].squeeze(),
-            "attention_mask": batch_encoding["attention_mask"],
+            "attention_mask": batch_encoding["attention_mask"].squeeze(),
         }
         return sample

--- a/genslm/hpc/submit.py
+++ b/genslm/hpc/submit.py
@@ -4,7 +4,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 import jinja2
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 import genslm
 
@@ -24,7 +24,8 @@ class HPCSettings(BaseModel):
     """CLI arguments for specified module."""
     genslm_path: Path = Path(genslm.__file__).parent
 
-    @validator("workdir")
+    @field_validator("workdir")
+    @classmethod
     def workdir_exists(cls, v: Path) -> Path:
         v = v.resolve()
         v.mkdir(exist_ok=True, parents=True)

--- a/genslm/inference.py
+++ b/genslm/inference.py
@@ -116,7 +116,7 @@ class GenSLM(nn.Module):
         if not weight_path.exists():
             # TODO: Implement model download
             raise NotImplementedError
-        ptl_checkpoint = torch.load(weight_path, map_location="cpu", weights_only=True)
+        ptl_checkpoint = torch.load(weight_path, map_location="cpu", weights_only=False)
         model.load_state_dict(ptl_checkpoint["state_dict"], strict=False)
         return model
 

--- a/genslm/inference.py
+++ b/genslm/inference.py
@@ -116,7 +116,7 @@ class GenSLM(nn.Module):
         if not weight_path.exists():
             # TODO: Implement model download
             raise NotImplementedError
-        ptl_checkpoint = torch.load(weight_path, map_location="cpu")
+        ptl_checkpoint = torch.load(weight_path, map_location="cpu", weights_only=True)
         model.load_state_dict(ptl_checkpoint["state_dict"], strict=False)
         return model
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ install_requires =
     natsort
     Jinja2
     transformers @ git+https://github.com/maxzvyagin/transformers
-    h5py==3.7.0
-    lightning-transformers==0.2.1
+    h5py
+    lightning-transformers
 python_requires = >=3.6
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages = find:
 install_requires = 
     pytorch-lightning
     wandb
-    pydantic==1.10.2
+    pydantic
     biopython
     pandas
     natsort

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 include_package_data = True
 packages = find:
 install_requires = 
-    pytorch-lightning==1.6.5
+    pytorch-lightning
     wandb
     pydantic==1.10.2
     biopython==1.79

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     pytorch-lightning
     wandb
     pydantic==1.10.2
-    biopython==1.79
+    biopython
     pandas
     natsort
     Jinja2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     pandas
     natsort
     Jinja2
-    transformers @ git+https://github.com/maxzvyagin/transformers
+    transformers # @ git+https://github.com/maxzvyagin/transformers
     h5py
     lightning-transformers
 python_requires = >=3.6


### PR DESCRIPTION
## Summary
- **Unpin dependencies**: Remove version constraints for transformers, biopython, pytorch-lightning, and pydantic to allow installation with modern package versions
- **Fix attention_mask shape**: Squeeze `attention_mask` in `SequenceDataset` and `InferenceSequenceDataset` to fix `IndexError` with newer transformers
- **Migrate to pydantic v2**: Replace deprecated `BaseSettings`/`validator`/`root_validator` with `BaseModel`/`field_validator`/`model_validator`
- **Fix PyTorch checkpoint loading**: Add `weights_only=False` parameter for compatibility with newer PyTorch versions
- Version bump and README updates

## Test plan
- [x] Verified forward pass with 25M model weights using the embedding notebook example
- [x] Full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)